### PR TITLE
Add import path alias support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-yaml-plugin",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "TypeScript Language Service plugin for YAML",
   "keywords": ["typescript", "ts", "typescript-5", "ts-5", "yaml", "yml", "plugin", "language-service", "intellisense", "autocomplete"],
   "author": "João Cabral Pinto",


### PR DESCRIPTION
The plugin is working for me for relative imports, but imports that use a path alias don't work (and also weirdly slow down my IDE type hints)

<img width="504" height="196" alt="image" src="https://github.com/user-attachments/assets/d506ff40-8cac-4f94-a612-01547bb971bb" />

This PR adds support for path alias. I wish I could somehow use TypeScript's default path resolution logic but I couldn't make it work, so it's done using a custom function instead.